### PR TITLE
add Z85::as_str method

### DIFF
--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -102,6 +102,13 @@ impl Z85 {
         Ok(Z85 { payload })
     }
 
+    /// Returns Z85 data as a str.
+    pub fn as_str(&self) -> &str {
+        // SAFETY: We know (through checking or constructing ourselves) that the payload
+        //         only contains valid Z85 encoding characters.
+        unsafe { std::str::from_utf8_unchecked(&self.payload) }
+    }
+
     /// Returns Z85 data as a slice.
     pub fn as_bytes(&self) -> &[u8] {
         self.payload.as_slice()
@@ -186,6 +193,13 @@ mod tests {
             let ls = encode_chunk(bs);
             let new_bs = decode_chunk(ls);
             prop_assert_eq!(new_bs ,bs);
+        }
+
+        #[test]
+        fn test_encode_chunk_is_unicode_prop(bs: [u8; 4]) {
+            let ls = encode_chunk(bs);
+            let ls_str_res = std::str::from_utf8(&ls);
+            prop_assert!(ls_str_res.is_ok());
         }
     }
 }


### PR DESCRIPTION
I'm using this library to print Z85-formatted strings, and the new 2.0 update has made it rather difficult to print the encoding result as a string.

At first I thought this use case is solved through the `Display` implementation on `Z85`, but it appears that it actually prints the payload as an array of bytes (via `Vec`'s `Debug` impl?).

This change adds an `as_str` method to `Z85`, in order to fill this gap.

Due to the internal representation being a `Vec<u8>` instead of `String`, this method unfortunately needs to use `unsafe` to provide a zero-overhead conversion. Perhaps this is something that may be worth revisiting?