### PR TITLE
Improve display fmt performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ categories = ["encoding"]
 
 [dev-dependencies]
 proptest = "0.9.4"
+criterion = "0.3.1"
 
 [dependencies]
 smallvec = "1.1.0"
+
+[[bench]]
+name = "display"
+harness = false

--- a/benches/display.rs
+++ b/benches/display.rs
@@ -1,0 +1,18 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use z85::{rfc::Z85, padded::Z85p};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("rfc", |b| {
+        let z = Z85::encode(&[0;32]).unwrap();
+        b.iter(|| format!("{}", black_box(z.clone())))
+    });
+
+    c.bench_function("padded", |b| {
+        let z = Z85p::encode(&[0;32]);
+        b.iter(|| format!("{}", black_box(z.clone())))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/padded.rs
+++ b/src/padded.rs
@@ -8,7 +8,7 @@ pub struct Z85p {
 
 impl fmt::Display for Z85p {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/rfc.rs
+++ b/src/rfc.rs
@@ -13,7 +13,7 @@ pub struct Z85 {
 
 impl fmt::Display for Z85 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        f.write_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
Interestingly, the `write!(f, "{}", self.as_str())` call doesn't optimize as well as I would've thought, so one needs to be more explicit to get good performance out of the `Display` impl.

Running the included benchmarks, this change shows a good amount of improvement (~10% reduction in runtime) on my machine:

```
rfc                     time:   [358.13 ns 364.20 ns 372.14 ns]
                        change: [-12.932% -11.637% -10.265%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

padded                  time:   [363.56 ns 365.61 ns 367.97 ns]
                        change: [-11.080% -9.8406% -8.5790%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
```

The benchmark is not super clean, because it includes `.clone` and `format!`, both of which will likely allocate, so the actual improvement for the `fmt` method alone may be more significant that indicated by the benchmark results.